### PR TITLE
Fix type in context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Type of `setAddress` function to allow function.
+
 ## [0.0.3] - 2020-03-10
 
 ### Changed

--- a/react/AddressContext.tsx
+++ b/react/AddressContext.tsx
@@ -1,10 +1,12 @@
 import React, { createContext, useContext, useState, useMemo } from 'react'
 import { Address } from 'vtex.checkout-graphql'
 
+type AddressUpdate = Address | ((prevAddress: Address) => Address)
+
 interface Context {
   countries: string[]
   address: Address
-  setAddress: (address: Address) => void
+  setAddress: (address: AddressUpdate) => void
 }
 
 interface AddressContextProps {


### PR DESCRIPTION
#### What problem is this solving?
The type of the `setAddress` function was too strict, and the context user should be able to update the address using an update function.

#### How should this be manually tested?
Linked in [this workspace](https://lucas--checkoutio.myvtex.com).

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->