### PR TITLE
CHK-98: Add Utils export with validateAddress function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Utils` export that provides a `validateAddress` function.
 
 ## [0.2.0] - 2020-07-10
 ### Added

--- a/react/Utils.ts
+++ b/react/Utils.ts
@@ -1,0 +1,44 @@
+import { Address } from 'vtex.checkout-graphql'
+
+import { AddressFields, AddressRules, Field } from './types'
+
+export const validateAddress = (
+  address: Address | null | undefined,
+  rules: AddressRules
+) => {
+  if (!address?.country || !rules[address.country]) {
+    return {
+      isValid: false,
+      invalidFields: [],
+    }
+  }
+
+  const invalidFields = (Object.entries(rules[address.country].fields) as Array<
+    [AddressFields, Field]
+  >)
+    .filter(([field, fieldSchema]) => {
+      const fieldValue = address[field]
+
+      if (fieldSchema.required && !fieldValue) {
+        return true
+      }
+
+      if (
+        fieldSchema.maxLength &&
+        fieldValue &&
+        fieldValue.length > fieldSchema.maxLength
+      ) {
+        return true
+      }
+
+      return false
+    })
+    .map(([field]) => field)
+
+  return {
+    isValid: invalidFields.length === 0,
+    invalidFields,
+  }
+}
+
+export default { validateAddress }


### PR DESCRIPTION
#### What problem is this solving?

This PR exposes a `validateAddress` function that takes an address and a `rules` object and returns whether the address is valid or not, along with an array of invalid fields. This is useful to validate addresses other than the one in the `AddressContext`.

#### How should this be manually tested?

Follow the test plan of https://github.com/vtex-apps/checkout-shipping/pull/11.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

