### PR TITLE
CHK-425: Add validation by pattern field of schema

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 - [ ] Updated `README.md`.
 - [ ] Updated `CHANGELOG.md`.
-- [ ] Linked this PR to a Clubhouse story (if applicable).
+- [ ] Linked this PR to a Jira story (if applicable).
 - [ ] Updated/created tests (important for bug fixes).
 - [ ] Deleted the workspace after merging this PR (if applicable).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Validation by `pattern` field of `AddressField` schema.
 
 ## [0.3.0] - 2020-07-15
 ### Added

--- a/react/Utils.ts
+++ b/react/Utils.ts
@@ -31,6 +31,10 @@ export const validateAddress = (
         return true
       }
 
+      if (fieldSchema.pattern) {
+        return fieldValue?.match(fieldSchema.pattern) === null
+      }
+
       return false
     })
     .map(([field]) => field)

--- a/react/types.tsx
+++ b/react/types.tsx
@@ -35,6 +35,7 @@ export interface Field {
    */
   mask?: string
   additionalData?: PostalCodeData | null
+  pattern?: string
 }
 
 export interface Display {
@@ -67,4 +68,6 @@ export interface CountryRules {
   locationSelect?: LocationSelect
 }
 
-export type AddressRules = { [key: string]: CountryRules }
+export interface AddressRules {
+  [key: string]: CountryRules
+}


### PR DESCRIPTION
#### What problem is this solving?

Validates the fields using the new `pattern` field of the schema.

#### How should this be manually tested?

[Workspace](https://lucas--checkoutio.myvtex.com/cart/add?sku=289).

The change in the workspace above is subtle, but these changes are what keeps us from showing an invalid postal code in the shipping calculator header (the part where it says "Por favor informe seu endereço" and the postal code when it is valid) when there is an error in it.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
