### PR TITLE
CHK-441: Allow null address and add createEmptyAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Utility function `createEmptyAddress`.
+
 ### Changed
 - Allow `null` to be passed as `address` in `AddressContextProvider`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Allow `null` to be passed as `address` in `AddressContextProvider`.
 
 ## [0.4.0] - 2020-10-30
 ### Added

--- a/react/AddressContext.tsx
+++ b/react/AddressContext.tsx
@@ -4,11 +4,11 @@ import { Address } from 'vtex.checkout-graphql'
 import { AddressRules, AddressFields } from './types'
 import { validateAddress } from './Utils'
 
-type AddressUpdate = Address | ((prevAddress: Address) => Address)
+type AddressUpdate = Address | null | ((prevAddress: Address | null) => Address)
 
 interface Context {
   countries: string[]
-  address: Address
+  address: Address | null
   setAddress: (address: AddressUpdate) => void
   rules: AddressRules
   isValid: boolean
@@ -16,7 +16,7 @@ interface Context {
 }
 
 interface AddressContextProps {
-  address: Address
+  address: Address | null
   countries: string[]
   rules: AddressRules
 }

--- a/react/AddressContext.tsx
+++ b/react/AddressContext.tsx
@@ -2,13 +2,13 @@ import React, { createContext, useContext, useState, useMemo } from 'react'
 import { Address } from 'vtex.checkout-graphql'
 
 import { AddressRules, AddressFields } from './types'
-import { validateAddress } from './Utils'
+import { validateAddress, createEmptyAddress } from './Utils'
 
-type AddressUpdate = Address | null | ((prevAddress: Address | null) => Address)
+type AddressUpdate = Address | ((prevAddress: Address) => Address)
 
 interface Context {
   countries: string[]
-  address: Address | null
+  address: Address
   setAddress: (address: AddressUpdate) => void
   rules: AddressRules
   isValid: boolean
@@ -29,7 +29,9 @@ export const AddressContextProvider: React.FC<AddressContextProps> = ({
   countries,
   rules = {},
 }) => {
-  const [localAddress, setLocalAddress] = useState(address)
+  const [localAddress, setLocalAddress] = useState(
+    () => address ?? createEmptyAddress()
+  )
 
   const { invalidFields, isValid } = useMemo(
     () => validateAddress(localAddress, rules),

--- a/react/Utils.ts
+++ b/react/Utils.ts
@@ -1,4 +1,4 @@
-import { Address } from 'vtex.checkout-graphql'
+import { Address, AddressType } from 'vtex.checkout-graphql'
 
 import { AddressFields, AddressRules, Field } from './types'
 
@@ -9,7 +9,18 @@ export const validateAddress = (
   if (!address?.country || !rules[address.country]) {
     return {
       isValid: false,
-      invalidFields: [],
+      invalidFields: [
+        'number',
+        'postalCode',
+        'city',
+        'complement',
+        'reference',
+        'neighborhood',
+        'state',
+        'country',
+        'receiverName',
+        'street',
+      ] as AddressFields[],
     }
   }
 
@@ -17,6 +28,10 @@ export const validateAddress = (
     [AddressFields, Field]
   >)
     .filter(([field, fieldSchema]) => {
+      if (field === 'isDisposable') {
+        return false
+      }
+
       const fieldValue = address[field]
 
       if (fieldSchema.required && !fieldValue) {
@@ -45,4 +60,23 @@ export const validateAddress = (
   }
 }
 
-export default { validateAddress }
+export const createEmptyAddress = (disposable = false): Address => {
+  return {
+    addressId: null,
+    addressType: 'residential' as AddressType,
+    geoCoordinates: [],
+    number: null,
+    postalCode: null,
+    city: null,
+    complement: null,
+    reference: null,
+    neighborhood: null,
+    state: null,
+    country: null,
+    receiverName: null,
+    street: null,
+    isDisposable: disposable,
+  }
+}
+
+export default { validateAddress, createEmptyAddress }

--- a/react/package.json
+++ b/react/package.json
@@ -9,8 +9,7 @@
   "devDependencies": {
     "@types/node": "^12.7.5",
     "@types/react": "^16.9.2",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.25.1/public/@types/vtex.checkout-graphql",
-    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.2/public/@types/vtex.order-manager",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime"
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.46.0/public/@types/vtex.checkout-graphql",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.3/public/@types/vtex.render-runtime"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -83,14 +83,10 @@ scheduler@^0.15.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.25.1/public/@types/vtex.checkout-graphql":
-  version "0.25.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.25.1/public/@types/vtex.checkout-graphql#c9f6ff21f6e16cf7c070e3b10439e0650e050c6d"
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.46.0/public/@types/vtex.checkout-graphql":
+  version "0.46.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.46.0/public/@types/vtex.checkout-graphql#9a530005a9a190fda003221b6b0d94430b0527dd"
 
-"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.2/public/@types/vtex.order-manager":
-  version "0.8.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.2/public/@types/vtex.order-manager#99a926da2acbfe7612306be3648228cf3469ce45"
-
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime":
-  version "8.94.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.94.0/public/@types/vtex.render-runtime#e79eb9a66801476b66e7ed354a83a7ff1f1c72c7"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.3/public/@types/vtex.render-runtime":
+  version "8.124.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.3/public/@types/vtex.render-runtime#8158e34bd24b4a51cb5d463eeef4e37af626c2d5"


### PR DESCRIPTION
#### What problem is this solving?

Allows passing `null` to `address` prop of `AddressContextProvider` and create a utility function to create an empty address (with the possibility to set it as diposable or not).

#### How should this be manually tested?

[Workspace](https://billing--checkoutio.myvtex.com/cart/add?sku=289).

The above workspace is still WIP but these changes are necessary for the feature I'm doing.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
